### PR TITLE
fix: improve mobile vault charts

### DIFF
--- a/src/components/charts/APYChart.tsx
+++ b/src/components/charts/APYChart.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react'
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from 'recharts'
 import { getTimeframeLimit } from '@/components/charts/chart-utils'
-import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/chart'
 import { Checkbox } from '@/components/ui/checkbox'
+import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/chart'
+import { useIsMobile } from '@/components/ui/use-mobile'
 import type { ChartDataPoint } from '@/types/dataTypes'
 
 type SeriesKey = 'derivedApy' | 'sevenDayApy' | 'thirtyDayApy' | 'oracleApr' | 'oracleApy30dAvg'
@@ -57,6 +58,7 @@ interface APYChartProps {
 
 export const APYChart: React.FC<APYChartProps> = React.memo(
   ({ chartData, timeframe, hideAxes, hideTooltip, defaultVisibleSeries }) => {
+    const isMobile = useIsMobile()
     const [visibleSeries, setVisibleSeries] = useState<Record<SeriesKey, boolean>>({
       derivedApy: defaultVisibleSeries?.derivedApy ?? true,
       sevenDayApy: defaultVisibleSeries?.sevenDayApy ?? true,
@@ -97,171 +99,175 @@ export const APYChart: React.FC<APYChartProps> = React.memo(
     const getSeriesLabel = (name: string) => seriesConfig[name as SeriesKey]?.legendLabel || name
 
     return (
-      <div className="relative h-full">
-        <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={filteredData}
-              margin={{
-                top: 20,
-                right: 30,
-                left: 10,
-                bottom: 20
-              }}
-            >
-              <CartesianGrid vertical={false} />
-              <XAxis
-                dataKey="date"
-                tick={
-                  hideAxes
-                    ? false
-                    : {
-                        fill: 'hsl(var(--muted-foreground))'
-                      }
-                }
-                axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
-                tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
-              />
-              <YAxis
-                domain={[0, 'auto']}
-                tickFormatter={(value) => `${value}%`}
-                label={
-                  hideAxes
-                    ? undefined
-                    : {
-                        value: 'Annualized %',
-                        angle: -90,
-                        position: 'insideLeft',
-                        offset: 10,
-                        style: {
-                          textAnchor: 'middle',
-                          fill: hideAxes ? 'transparent' : 'hsl(var(--muted-foreground))'
+      <div className="flex h-full flex-col">
+        <div className="relative min-h-0 flex-1">
+          <ChartContainer config={chartConfig} style={{ height: '100%' }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={filteredData}
+                margin={{
+                  top: 12,
+                  right: isMobile ? 8 : 20,
+                  left: isMobile ? -20 : 0,
+                  bottom: hideAxes ? 8 : isMobile ? 12 : 16
+                }}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="date"
+                  minTickGap={isMobile ? 32 : 24}
+                  interval={hideAxes ? 'preserveStartEnd' : undefined}
+                  tick={
+                    hideAxes
+                      ? false
+                      : {
+                          fill: 'hsl(var(--muted-foreground))',
+                          fontSize: isMobile ? 11 : 12
                         }
-                      }
-                }
-                tick={
-                  hideAxes
-                    ? false
-                    : {
-                        fill: 'hsl(var(--muted-foreground))'
-                      }
-                }
-                axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
-                tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
-              />
-              {!hideTooltip && (
-                <ChartTooltip
-                  content={({ active, label, payload }) => {
-                    if (!active || !payload?.length) return null
+                  }
+                  axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+                  tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+                />
+                <YAxis
+                  width={isMobile ? 44 : 60}
+                  domain={[0, 'auto']}
+                  tickFormatter={(value) => `${value}%`}
+                  label={
+                    hideAxes || isMobile
+                      ? undefined
+                      : {
+                          value: 'Annualized %',
+                          angle: -90,
+                          position: 'insideLeft',
+                          offset: 10,
+                          style: {
+                            textAnchor: 'middle',
+                            fill: hideAxes ? 'transparent' : 'hsl(var(--muted-foreground))'
+                          }
+                        }
+                  }
+                  tick={
+                    hideAxes
+                      ? false
+                      : {
+                          fill: 'hsl(var(--muted-foreground))',
+                          fontSize: isMobile ? 11 : 12
+                        }
+                  }
+                  axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+                  tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+                />
+                {!hideTooltip && (
+                  <ChartTooltip
+                    content={({ active, label, payload }) => {
+                      if (!active || !payload?.length) return null
 
-                    const sorted = [...payload].sort((a, b) => {
-                      const aKey = a.dataKey as SeriesKey
-                      const bKey = b.dataKey as SeriesKey
-                      return (TOOLTIP_ORDER[aKey] ?? 999) - (TOOLTIP_ORDER[bKey] ?? 999)
-                    })
+                      const sorted = [...payload].sort((a, b) => {
+                        const aKey = a.dataKey as SeriesKey
+                        const bKey = b.dataKey as SeriesKey
+                        return (TOOLTIP_ORDER[aKey] ?? 999) - (TOOLTIP_ORDER[bKey] ?? 999)
+                      })
 
-                    return (
-                      <div className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
-                        <div className="font-medium">{label}</div>
-                        <div className="grid gap-1.5">
-                          {sorted.map((item) => {
-                            const seriesKey = item.dataKey as SeriesKey
-                            const raw = item.value
-                            const value = typeof raw === 'number' ? `${raw.toFixed(2)}%` : raw
+                      return (
+                        <div className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+                          <div className="font-medium">{label}</div>
+                          <div className="grid gap-1.5">
+                            {sorted.map((item) => {
+                              const seriesKey = item.dataKey as SeriesKey
+                              const raw = item.value
+                              const value = typeof raw === 'number' ? `${raw.toFixed(2)}%` : raw
 
-                            const color =
-                              (item.color as string | undefined) ||
-                              (item.stroke as string | undefined) ||
-                              'currentColor'
+                              const color =
+                                (item.color as string | undefined) ||
+                                (item.stroke as string | undefined) ||
+                                'currentColor'
 
-                            return (
-                              <div key={`${item.dataKey}`} className="flex items-center justify-between gap-3">
-                                <div className="flex items-center gap-2">
-                                  <svg aria-hidden="true" width={18} height={6} viewBox="0 0 18 6" className="shrink-0">
-                                    <line
-                                      x1="0"
-                                      y1="3"
-                                      x2="18"
-                                      y2="3"
-                                      stroke={color}
-                                      strokeWidth="2"
-                                      strokeDasharray={
-                                        // Use the same dash pattern as the chart series for visual consistency
-                                        isDashedSeries(seriesKey) ? '12 4' : undefined
-                                      }
-                                      strokeLinecap="butt"
-                                    />
-                                  </svg>
-                                  <span>{getSeriesLabel(String(item.dataKey))}</span>
+                              return (
+                                <div key={`${item.dataKey}`} className="flex items-center justify-between gap-3">
+                                  <div className="flex items-center gap-2">
+                                    <svg aria-hidden="true" width={18} height={6} viewBox="0 0 18 6" className="shrink-0">
+                                      <line
+                                        x1="0"
+                                        y1="3"
+                                        x2="18"
+                                        y2="3"
+                                        stroke={color}
+                                        strokeWidth="2"
+                                        strokeDasharray={isDashedSeries(seriesKey) ? '12 4' : undefined}
+                                        strokeLinecap="butt"
+                                      />
+                                    </svg>
+                                    <span>{getSeriesLabel(String(item.dataKey))}</span>
+                                  </div>
+                                  <span className="tabular-nums">{value}</span>
                                 </div>
-                                <span className="tabular-nums">{value}</span>
-                              </div>
-                            )
-                          })}
+                              )
+                            })}
+                          </div>
                         </div>
-                      </div>
-                    )
-                  }}
-                />
-              )}
-              {visibleSeries.sevenDayApy && (
-                <Line
-                  type="monotone"
-                  dataKey="sevenDayApy"
-                  stroke="var(--color-sevenDayApy)"
-                  strokeWidth={hideAxes ? 1 : 1.5}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-              {visibleSeries.thirtyDayApy && (
-                <Line
-                  type="monotone"
-                  dataKey="thirtyDayApy"
-                  stroke="var(--color-thirtyDayApy)"
-                  strokeDasharray="12 4"
-                  strokeWidth={hideAxes ? 1 : 2.5}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-              {visibleSeries.derivedApy && (
-                <Line
-                  type="monotone"
-                  dataKey="derivedApy"
-                  stroke="var(--color-derivedApy)"
-                  strokeWidth={hideAxes ? 1 : 1}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-              {hasOracleApr && visibleSeries.oracleApr && (
-                <Line
-                  type="monotone"
-                  dataKey="oracleApr"
-                  stroke="var(--color-oracleApr)"
-                  strokeWidth={hideAxes ? 1 : 2}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-              {hasOracleApy30dAvg && visibleSeries.oracleApy30dAvg && (
-                <Line
-                  type="monotone"
-                  dataKey="oracleApy30dAvg"
-                  stroke="var(--color-oracleApy30dAvg)"
-                  strokeDasharray="12 4"
-                  strokeWidth={hideAxes ? 1 : 2.75}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-            </LineChart>
-          </ResponsiveContainer>
-        </ChartContainer>
+                      )
+                    }}
+                  />
+                )}
+                {visibleSeries.sevenDayApy && (
+                  <Line
+                    type="monotone"
+                    dataKey="sevenDayApy"
+                    stroke="var(--color-sevenDayApy)"
+                    strokeWidth={hideAxes ? 1 : 1.5}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                )}
+                {visibleSeries.thirtyDayApy && (
+                  <Line
+                    type="monotone"
+                    dataKey="thirtyDayApy"
+                    stroke="var(--color-thirtyDayApy)"
+                    strokeDasharray="12 4"
+                    strokeWidth={hideAxes ? 1 : 2.5}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                )}
+                {visibleSeries.derivedApy && (
+                  <Line
+                    type="monotone"
+                    dataKey="derivedApy"
+                    stroke="var(--color-derivedApy)"
+                    strokeWidth={hideAxes ? 1 : 1}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                )}
+                {hasOracleApr && visibleSeries.oracleApr && (
+                  <Line
+                    type="monotone"
+                    dataKey="oracleApr"
+                    stroke="var(--color-oracleApr)"
+                    strokeWidth={hideAxes ? 1 : 2}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                )}
+                {hasOracleApy30dAvg && visibleSeries.oracleApy30dAvg && (
+                  <Line
+                    type="monotone"
+                    dataKey="oracleApy30dAvg"
+                    stroke="var(--color-oracleApy30dAvg)"
+                    strokeDasharray="12 4"
+                    strokeWidth={hideAxes ? 1 : 2.75}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                )}
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartContainer>
+        </div>
         {!hideAxes && (
-          <div className="absolute inset-x-0 bottom-[-1rem] flex justify-center">
-            <div className="flex flex-wrap items-center justify-center gap-4 rounded-md bg-white/80 px-4 py-2 text-xs">
+          <div className="mt-3 flex justify-center">
+            <div className="flex w-full flex-wrap items-center justify-center gap-x-4 gap-y-2 rounded-md border border-border/60 bg-white/90 px-3 py-2 text-xs sm:w-fit sm:px-4">
               {seriesOrder
                 .filter((seriesKey) => {
                   if (seriesKey === 'oracleApr') return hasOracleApr
@@ -269,7 +275,7 @@ export const APYChart: React.FC<APYChartProps> = React.memo(
                   return true
                 })
                 .map((seriesKey) => (
-                  <div key={seriesKey} className="flex items-center gap-2">
+                  <div key={seriesKey} className="flex min-w-[8.75rem] items-center gap-2 sm:min-w-0">
                     <Checkbox
                       id={`toggle-${seriesKey}`}
                       checked={visibleSeries[seriesKey]}

--- a/src/components/charts/PPSChart.tsx
+++ b/src/components/charts/PPSChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from 'recharts'
 import { getTimeframeLimit } from '@/components/charts/chart-utils'
 import { ChartContainer, ChartTooltip } from '@/components/ui/chart'
+import { useIsMobile } from '@/components/ui/use-mobile'
 import type { ChartDataPoint } from '@/types/dataTypes'
 
 type PercentSeriesKey = 'derivedApr'
@@ -16,6 +17,7 @@ interface PPSChartProps {
 
 export const PPSChart: React.FC<PPSChartProps> = React.memo(
   ({ chartData, timeframe, hideAxes, hideTooltip, dataKey = 'PPS' }) => {
+    const isMobile = useIsMobile()
     const filteredData = useMemo(() => chartData.slice(-getTimeframeLimit(timeframe)), [chartData, timeframe])
 
     const isPercentSeries = dataKey !== 'PPS'
@@ -44,36 +46,39 @@ export const PPSChart: React.FC<PPSChartProps> = React.memo(
                 }
               }
         }
-        style={{ height: 'inherit' }}
+        style={{ height: '100%' }}
       >
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
             data={filteredData}
             margin={{
-              top: 20,
-              right: 30,
-              left: 10,
-              bottom: 20
+              top: 12,
+              right: isMobile ? 8 : 20,
+              left: isMobile ? -20 : 0,
+              bottom: hideAxes ? 8 : isMobile ? 12 : 16
             }}
           >
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey="date"
+              minTickGap={isMobile ? 32 : 24}
               tick={
                 hideAxes
                   ? false
                   : {
-                      fill: 'hsl(var(--muted-foreground))'
+                      fill: 'hsl(var(--muted-foreground))',
+                      fontSize: isMobile ? 11 : 12
                     }
               }
               axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
               tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
             />
             <YAxis
+              width={isMobile ? 44 : 60}
               domain={isPercentSeries ? [0, 'auto'] : ['auto', 'auto']}
               tickFormatter={(value) => (isPercentSeries ? `${value}%` : Number(value).toFixed(3))}
               label={
-                hideAxes
+                hideAxes || isMobile
                   ? undefined
                   : {
                       value: isPercentSeries && activePercentMeta ? activePercentMeta.label : 'Price Per Share',
@@ -90,7 +95,8 @@ export const PPSChart: React.FC<PPSChartProps> = React.memo(
                 hideAxes
                   ? false
                   : {
-                      fill: 'hsl(var(--muted-foreground))'
+                      fill: 'hsl(var(--muted-foreground))',
+                      fontSize: isMobile ? 11 : 12
                     }
               }
               axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}

--- a/src/components/charts/TVLChart.tsx
+++ b/src/components/charts/TVLChart.tsx
@@ -2,102 +2,91 @@ import React, { useMemo } from 'react'
 import { Bar, CartesianGrid, ComposedChart, ResponsiveContainer, XAxis, YAxis } from 'recharts'
 import { getTimeframeLimit } from '@/components/charts/chart-utils'
 import { ChartContainer, ChartTooltip } from '@/components/ui/chart'
+import { useIsMobile } from '@/components/ui/use-mobile'
 import type { ChartDataPoint } from '@/types/dataTypes'
 
 interface TVLChartProps {
   chartData: ChartDataPoint[]
   timeframe: string
-  hideAxes?: boolean // Added prop for hiding axes
-  hideTooltip?: boolean // Added prop for hiding tooltip
+  hideAxes?: boolean
+  hideTooltip?: boolean
 }
 
 const formatTooltipValue = (value: number) => {
   return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
 }
 
-// Converted to a React function component with arrow syntax
-export const TVLChart: React.FC<TVLChartProps> = React.memo(
-  ({
-    // memoized
-    chartData,
-    timeframe,
-    hideAxes,
-    hideTooltip
-  }) => {
-    const filteredData = useMemo(() => chartData.slice(-getTimeframeLimit(timeframe)), [chartData, timeframe])
+export const TVLChart: React.FC<TVLChartProps> = React.memo(({ chartData, timeframe, hideAxes, hideTooltip }) => {
+  const isMobile = useIsMobile()
+  const filteredData = useMemo(() => chartData.slice(-getTimeframeLimit(timeframe)), [chartData, timeframe])
 
-    return (
-      <ChartContainer
-        config={{
-          value: { label: 'TVL (millions)', color: 'var(--chart-1)' }
-        }}
-        style={{ height: 'inherit' }}
-      >
-        <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart
-            data={filteredData}
-            margin={{
-              top: 20,
-              right: 30,
-              left: 10, // Increased left margin for Y-axis label
-              bottom: 20
-            }}
-          >
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tick={
-                hideAxes
-                  ? false
-                  : {
+  return (
+    <ChartContainer
+      config={{
+        value: { label: 'TVL (millions)', color: 'var(--chart-1)' }
+      }}
+      style={{ height: '100%' }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart
+          data={filteredData}
+          margin={{
+            top: 12,
+            right: isMobile ? 8 : 20,
+            left: isMobile ? -18 : 0,
+            bottom: hideAxes ? 8 : isMobile ? 12 : 16
+          }}
+        >
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="date"
+            minTickGap={isMobile ? 32 : 24}
+            tick={
+              hideAxes
+                ? false
+                : {
+                    fill: 'hsl(var(--muted-foreground))',
+                    fontSize: isMobile ? 11 : 12
+                  }
+            }
+            axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+            tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+          />
+          <YAxis
+            width={isMobile ? 52 : 68}
+            domain={[0, 'auto']}
+            tickFormatter={(value) => `$${(value / 1_000_000).toFixed(1)}M`}
+            label={
+              hideAxes || isMobile
+                ? undefined
+                : {
+                    value: 'TVL ($ millions)',
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: {
+                      textAnchor: 'middle',
                       fill: 'hsl(var(--muted-foreground))'
                     }
-              } // Hide ticks when hideAxes is true
-              axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }} // Hide axis line
-              tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }} // Hide tick lines
-            />
-            <YAxis
-              domain={[0, 'auto']}
-              tickFormatter={(value) => `$${(value / 1_000_000).toFixed(1)}M`}
-              label={
-                hideAxes
-                  ? undefined
-                  : {
-                      value: 'TVL ($ millions)',
-                      angle: -90,
-                      position: 'insideLeft',
-                      offset: 10,
-                      style: {
-                        textAnchor: 'middle',
-                        fill: 'hsl(var(--muted-foreground))' // Added fill color
-                      }
-                    }
-              } // Hide label when hideAxes is true
-              tick={
-                hideAxes
-                  ? false
-                  : {
-                      fill: 'hsl(var(--muted-foreground))'
-                    }
-              } // Hide ticks when hideAxes is true
-              axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }} // Hide axis line
-              tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }} // Hide tick lines
-            />
-            {!hideTooltip && <ChartTooltip formatter={formatTooltipValue} />}
-            <Bar
-              dataKey="TVL"
-              fill={'var(--color-value)'}
-              stroke={'transparent'}
-              // fill={hideAxes ? 'transparent' : 'var(--color-value)'}
-              // stroke={hideAxes ? 'var(--color-value)' : 'transparent'}
-              radius={[4, 4, 0, 0]}
-              isAnimationActive={false}
-            />
-          </ComposedChart>
-        </ResponsiveContainer>
-      </ChartContainer>
-    )
-  }
-)
+                  }
+            }
+            tick={
+              hideAxes
+                ? false
+                : {
+                    fill: 'hsl(var(--muted-foreground))',
+                    fontSize: isMobile ? 11 : 12
+                  }
+            }
+            axisLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+            tickLine={hideAxes ? false : { stroke: 'hsl(var(--muted-foreground))' }}
+          />
+          {!hideTooltip && <ChartTooltip formatter={formatTooltipValue} />}
+          <Bar dataKey="TVL" fill="var(--color-value)" stroke="transparent" radius={[4, 4, 0, 0]} isAnimationActive={false} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  )
+})
 
 export default TVLChart

--- a/src/components/charts/chart-container.tsx
+++ b/src/components/charts/chart-container.tsx
@@ -3,11 +3,16 @@ import type React from 'react'
 interface ChartContainerProps {
   children: React.ReactNode
   className?: string
+  heightClassName?: string
 }
 
-export function FixedHeightChartContainer({ children, className = '' }: ChartContainerProps) {
+export function FixedHeightChartContainer({
+  children,
+  className = '',
+  heightClassName = 'h-[280px] sm:h-[360px] lg:h-[400px]'
+}: ChartContainerProps) {
   return (
-    <div className={`${className} relative h-[400px]`}>
+    <div className={`${className} relative ${heightClassName}`}>
       <div
         className="absolute inset-0"
         style={
@@ -15,14 +20,11 @@ export function FixedHeightChartContainer({ children, className = '' }: ChartCon
             '--chart-1': '#46a2ff',
             '--chart-2': '#46a2ff',
             '--chart-3': '#94adf2',
-            // '--chart-3': '#6786db',
             '--chart-4': '#b0b5bf'
           } as React.CSSProperties
         }
       >
-        {/* This div will force all children to take full height */}
         <div className="h-full w-full">
-          {/* Apply styles to override aspect-ratio */}
           <style>{`
             .aspect-video {
               aspect-ratio: auto !important;

--- a/src/components/charts/charts-panel.tsx
+++ b/src/components/charts/charts-panel.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import APYChart from '@/components/charts/APYChart'
 import ChartSkeleton from '@/components/charts/ChartSkeleton'
 import ChartsLoader from '@/components/charts/ChartsLoader'
 import { FixedHeightChartContainer } from '@/components/charts/chart-container'
 import PPSChart from '@/components/charts/PPSChart'
 import TVLChart from '@/components/charts/TVLChart'
+import { useIsMobile } from '@/components/ui/use-mobile'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ChartErrorBoundary } from '@/components/utils/ErrorBoundary'
 import type { aprApyChartData, ppsChartData, tvlChartData } from '@/types/dataTypes'
@@ -17,32 +18,41 @@ type ChartData = {
   hasErrors?: boolean
 }
 
+type ChartTab = 'historical-apy' | 'historical-pps' | 'historical-tvl'
+
+const chartTabs: Array<{
+  value: ChartTab
+  label: string
+  mobileLabel: string
+}> = [
+  { value: 'historical-apy', label: 'Historical Performance', mobileLabel: 'Performance' },
+  { value: 'historical-pps', label: 'Historical Share Growth', mobileLabel: 'Share Growth' },
+  { value: 'historical-tvl', label: 'Historical TVL', mobileLabel: 'TVL' }
+]
+
+const timeframes = [
+  { label: '30 Days', mobileLabel: '30D', value: '30d' },
+  { label: '90 Days', mobileLabel: '90D', value: '90d' },
+  { label: '1 Year', mobileLabel: '1Y', value: '1y' },
+  { label: 'All Time', mobileLabel: 'All', value: 'all' }
+] as const
+
 export function ChartsPanel(data: ChartData) {
-  const [activeTab, setActiveTab] = useState('historical-apy')
+  const isMobile = useIsMobile()
+  const [activeTab, setActiveTab] = useState<ChartTab>('historical-apy')
   const { aprApyData, tvlData, ppsData, isLoading = false, hasErrors = false } = data
+  const [timeframe, setTimeframe] = useState(timeframes[3])
 
-  // Define timeframe options with values that match the chart component expectations
-  const timeframes = [
-    { label: '30 Days', value: '30d' },
-    { label: '90 Days', value: '90d' },
-    { label: '1 Year', value: '1y' },
-    { label: 'All Time', value: 'all' }
-  ]
-
-  const [timeframe, setTimeframe] = useState(timeframes[3]) // Default to All Time
-
-  // Show error state if there are errors
   if (hasErrors) {
     return (
       <div className="border-x border-border bg-white">
-        <div className="h-96 flex items-center justify-center">
+        <div className="flex h-96 items-center justify-center">
           <div className="text-red-500">Error loading chart data</div>
         </div>
       </div>
     )
   }
 
-  // Show skeleton with loader overlay when loading or no data yet
   if (isLoading || !aprApyData || !tvlData || !ppsData) {
     return (
       <div className="relative">
@@ -52,94 +62,53 @@ export function ChartsPanel(data: ChartData) {
     )
   }
 
-  // Define chart titles and descriptions based on active tab
   const chartInfo = {
     'historical-apy': {
-      title: 'Vault Performance (TVL shown ghosted)',
-      description: `1-Day, 7-Day, and 30-Day APYs over ${timeframe.label}.`
+      title: 'Vault Performance',
+      description: `1-Day, 7-Day, and 30-Day APYs over ${timeframe.label}.`,
+      mobileDescription: `Compare APY trends over ${timeframe.mobileLabel}.`
     },
     'historical-pps': {
-      title: 'Vault Share Growth (1-Day APY shown ghosted)',
-      description: `Price Per Share values over ${timeframe.label}.`
+      title: 'Vault Share Growth',
+      description: `Price Per Share values over ${timeframe.label}.`,
+      mobileDescription: `Track share price growth over ${timeframe.mobileLabel}.`
     },
     'historical-tvl': {
-      title: 'Total Value Deposited (APY shown ghosted)',
-      description: `Value Deposited in Vault over ${timeframe.label}.`
+      title: 'Total Value Deposited',
+      description: `Value deposited in vault over ${timeframe.label}.`,
+      mobileDescription: `Review TVL changes over ${timeframe.mobileLabel}.`
     }
-  }
+  } satisfies Record<ChartTab, { title: string; description: string; mobileDescription: string }>
 
-  return (
-    <div className="border-x border-border bg-white">
-      <Tabs defaultValue="historical-apy" className="w-full" onValueChange={(value) => setActiveTab(value)}>
-        <div className="border-b border-border">
-          <div className="px-0 pt-4">
-            <TabsList className="grid w-fit grid-cols-3 bg-transparent p-0">
-              <TabsTrigger
-                value="historical-apy"
-                className="rounded-none border-b-2 border-transparent px-4 py-2 data-[state=active]:border-[#0657f9] data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-              >
-                Historical Performance
-              </TabsTrigger>
-              <TabsTrigger
-                value="historical-pps"
-                className="rounded-none border-b-2 border-transparent px-4 py-2 data-[state=active]:border-[#0657f9] data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-              >
-                Historical Share Growth
-              </TabsTrigger>
-              <TabsTrigger
-                value="historical-tvl"
-                className="rounded-none border-b-2 border-transparent px-4 py-2 data-[state=active]:border-[#0657f9] data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-              >
-                Historical TVL
-              </TabsTrigger>
-            </TabsList>
-          </div>
-        </div>
+  const activeChartInfo = chartInfo[activeTab]
+  const showGhostedOverlay = !isMobile
+  const chartHeightClassName = isMobile ? 'h-[260px]' : 'h-[320px] lg:h-[400px]'
 
-        <div className="p-6">
-          <div className="flex justify-between items-center mb-4">
-            <div>
-              <div className="text-sm font-medium">{chartInfo[activeTab as keyof typeof chartInfo].title}</div>
-              <div className="text-xs text-gray-500">{chartInfo[activeTab as keyof typeof chartInfo].description}</div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {timeframes.map((tf) => (
-                <button
-                  key={tf.value}
-                  onClick={() => setTimeframe(tf)}
-                  className={`px-3 py-1 text-sm ${
-                    timeframe.value === tf.value
-                      ? 'bg-gray-200 text-gray-800'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                  }`}
-                >
-                  {tf.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <TabsContent value="historical-apy" className="mt-0">
-            <FixedHeightChartContainer>
-              <ChartErrorBoundary>
-                <APYChart chartData={aprApyData} timeframe={timeframe.value} />
-              </ChartErrorBoundary>
-              <div className="absolute inset-0 opacity-10 pointer-events-none">
-                {/* Ghosted TVL chart */}
+  const chartBody = useMemo(() => {
+    switch (activeTab) {
+      case 'historical-apy':
+        return (
+          <FixedHeightChartContainer heightClassName={chartHeightClassName}>
+            <ChartErrorBoundary>
+              <APYChart chartData={aprApyData} timeframe={timeframe.value} />
+            </ChartErrorBoundary>
+            {showGhostedOverlay && (
+              <div className="pointer-events-none absolute inset-0 opacity-10">
                 <ChartErrorBoundary>
                   <TVLChart chartData={tvlData} timeframe={timeframe.value} hideAxes={true} hideTooltip={true} />
                 </ChartErrorBoundary>
               </div>
-            </FixedHeightChartContainer>
-          </TabsContent>
-
-          <TabsContent value="historical-pps" className="mt-0">
-            <FixedHeightChartContainer>
-              <ChartErrorBoundary>
-                <PPSChart chartData={ppsData} timeframe={timeframe.value} />
-              </ChartErrorBoundary>
-              <div className="absolute inset-0 opacity-30 pointer-events-none">
-                {/* Ghosted APY chart (7-day) */}
+            )}
+          </FixedHeightChartContainer>
+        )
+      case 'historical-pps':
+        return (
+          <FixedHeightChartContainer heightClassName={chartHeightClassName}>
+            <ChartErrorBoundary>
+              <PPSChart chartData={ppsData} timeframe={timeframe.value} />
+            </ChartErrorBoundary>
+            {showGhostedOverlay && (
+              <div className="pointer-events-none absolute inset-0 opacity-30">
                 <ChartErrorBoundary>
                   <APYChart
                     chartData={aprApyData}
@@ -156,16 +125,17 @@ export function ChartsPanel(data: ChartData) {
                   />
                 </ChartErrorBoundary>
               </div>
-            </FixedHeightChartContainer>
-          </TabsContent>
-
-          <TabsContent value="historical-tvl" className="mt-0">
-            <FixedHeightChartContainer>
-              <ChartErrorBoundary>
-                <TVLChart chartData={tvlData} timeframe={timeframe.value} />
-              </ChartErrorBoundary>
-              <div className="absolute inset-0 opacity-30 pointer-events-none">
-                {/* Ghosted APY chart (7-day) */}
+            )}
+          </FixedHeightChartContainer>
+        )
+      case 'historical-tvl':
+        return (
+          <FixedHeightChartContainer heightClassName={chartHeightClassName}>
+            <ChartErrorBoundary>
+              <TVLChart chartData={tvlData} timeframe={timeframe.value} />
+            </ChartErrorBoundary>
+            {showGhostedOverlay && (
+              <div className="pointer-events-none absolute inset-0 opacity-30">
                 <ChartErrorBoundary>
                   <APYChart
                     chartData={aprApyData}
@@ -182,7 +152,70 @@ export function ChartsPanel(data: ChartData) {
                   />
                 </ChartErrorBoundary>
               </div>
-            </FixedHeightChartContainer>
+            )}
+          </FixedHeightChartContainer>
+        )
+    }
+  }, [activeTab, aprApyData, chartHeightClassName, ppsData, showGhostedOverlay, timeframe.value, tvlData])
+
+  return (
+    <div className="border-x border-border bg-white">
+      <Tabs value={activeTab} className="w-full" onValueChange={(value) => setActiveTab(value as ChartTab)}>
+        <div className="border-b border-border">
+          <div className="px-4 pt-4 sm:px-6">
+            <TabsList className="grid h-auto w-full grid-cols-1 gap-2 bg-transparent p-0 sm:w-fit sm:grid-cols-3 sm:gap-0">
+              {chartTabs.map((tab) => (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className="h-auto rounded-none border border-border px-4 py-3 text-left text-sm data-[state=active]:border-[#0657f9] data-[state=active]:bg-[#0657f9]/5 data-[state=active]:text-foreground data-[state=active]:shadow-none sm:border-x-0 sm:border-t-0 sm:border-b-2 sm:text-center"
+                >
+                  {isMobile ? tab.mobileLabel : tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-4 sm:p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">{activeChartInfo.title}</div>
+              <div className="text-xs text-gray-500">
+                {isMobile ? activeChartInfo.mobileDescription : activeChartInfo.description}
+              </div>
+              {isMobile && (
+                <div className="text-[11px] text-gray-400">Tap the series toggles below the chart to simplify the view.</div>
+              )}
+            </div>
+            <div className="grid grid-cols-4 gap-2 sm:flex sm:flex-wrap">
+              {timeframes.map((tf) => (
+                <button
+                  key={tf.value}
+                  onClick={() => setTimeframe(tf)}
+                  className={`min-w-0 rounded-md px-3 py-2 text-center text-xs font-medium transition-colors sm:text-sm ${
+                    timeframe.value === tf.value
+                      ? 'bg-[#0657f9] text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                  type="button"
+                >
+                  {isMobile ? tf.mobileLabel : tf.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <TabsContent value="historical-apy" className="mt-0">
+            {activeTab === 'historical-apy' ? chartBody : null}
+          </TabsContent>
+
+          <TabsContent value="historical-pps" className="mt-0">
+            {activeTab === 'historical-pps' ? chartBody : null}
+          </TabsContent>
+
+          <TabsContent value="historical-tvl" className="mt-0">
+            {activeTab === 'historical-tvl' ? chartBody : null}
           </TabsContent>
         </div>
       </Tabs>


### PR DESCRIPTION
### Motivation

- Vault detail charts were difficult to use on narrow screens because overlays, legends, and spacing made the chart area cluttered and hard to interact with.  
- Controls (timeframe buttons and series toggles) were not optimised for touch and small viewports.  
- Charts needed consistent, smaller footprints on mobile so the vault page remains useful without horizontal scrolling or truncated UI.

### Description

- Make the charts panel responsive by detecting small screens with `useIsMobile()` and switching to stacked mobile-friendly tab labels, shorter timeframe labels, and reduced chart heights (`src/components/charts/charts-panel.tsx`).  
- Add a `heightClassName` prop to the fixed chart wrapper so charts use smaller heights on mobile and larger heights on desktop (`src/components/charts/chart-container.tsx`).  
- Tune chart layouts and margins for small screens and reduce axis footprint by using `useIsMobile()` inside `APYChart`, `PPSChart`, and `TVLChart` to adjust `margin`, `minTickGap`, tick font sizes, Y-axis width, and to hide axis labels on mobile (`src/components/charts/APYChart.tsx`, `src/components/charts/PPSChart.tsx`, `src/components/charts/TVLChart.tsx`).  
- Reduce mobile clutter by disabling the ghosted overlay charts on mobile (kept for larger screens) and move the APY series toggles into a wrapped control block below the APY chart so they remain tappable on phones (`src/components/charts/charts-panel.tsx`, `src/components/charts/APYChart.tsx`).

### Testing

- `git diff --check` was run and returned no whitespace/merge errors.  
- `npm test -- --runInBand` was attempted but failed in this environment because project dependencies were not installed (Vitest not found).  
- `npm run build` was attempted but also failed because dependencies could not be installed in this environment (registry access returned 403), so build-time type checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb17f667e483288a31d864b0f199b0)